### PR TITLE
Onboarding loadez/task8

### DIFF
--- a/finished_code/src/debug/java/com/example/android/kotlincoroutines/fakes/TestingFakes.kt
+++ b/finished_code/src/debug/java/com/example/android/kotlincoroutines/fakes/TestingFakes.kt
@@ -107,5 +107,4 @@ class MainNetworkCompletableFake() : MainNetwork {
         completable.completeExceptionally(throwable)
         completable = CompletableDeferred()
     }
-
 }

--- a/start/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
+++ b/start/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
@@ -16,6 +16,12 @@
 
 package com.example.android.kotlincoroutines.main
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker.Result
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.example.android.kotlincoroutines.fakes.MainNetworkFake
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -25,6 +31,12 @@ class RefreshMainDataWorkTest {
 
     @Test
     fun testRefreshMainDataWork() {
-        // TODO: Write this test
+        val fakeNetwork = MainNetworkFake("OK")
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val worker = TestListenableWorkerBuilder<RefreshMainDataWork>(context)
+            .setWorkerFactory(RefreshMainDataWork.Factory(fakeNetwork))
+            .build()
+        val result = worker.startWork().get()
+        assertThat(result).isEqualTo(Result.success())
     }
 }

--- a/start/src/debug/java/com/example/android/kotlincoroutines/fakes/TestingFakes.kt
+++ b/start/src/debug/java/com/example/android/kotlincoroutines/fakes/TestingFakes.kt
@@ -46,7 +46,7 @@ class TitleDaoFake(initialTitle: String) : TitleDao {
      */
     private val insertedForNext = Channel<Title>(capacity = Channel.BUFFERED)
 
-    override fun insertTitle(title: Title) {
+    override suspend fun insertTitle(title: Title) {
         insertedForNext.trySend(title)
         _titleLiveData.value = title
     }
@@ -92,7 +92,7 @@ class TitleDaoFake(initialTitle: String) : TitleDao {
  * Testing Fake implementation of MainNetwork
  */
 class MainNetworkFake(var result: String) : MainNetwork {
-    override fun fetchNextTitle() = MakeCompilerHappyForStarterCode() // TODO: replace with `result`
+    override suspend fun fetchNextTitle(): String = result
 }
 
 /**
@@ -101,7 +101,7 @@ class MainNetworkFake(var result: String) : MainNetwork {
 class MainNetworkCompletableFake() : MainNetwork {
     private var completable = CompletableDeferred<String>()
 
-    override fun fetchNextTitle() = MakeCompilerHappyForStarterCode() // TODO: replace with `completable.await()`
+    override suspend fun fetchNextTitle() = completable.await()
 
     fun sendCompletionToAllCurrentRequests(result: String) {
         completable.complete(result)
@@ -112,7 +112,6 @@ class MainNetworkCompletableFake() : MainNetwork {
         completable.completeExceptionally(throwable)
         completable = CompletableDeferred()
     }
-
 }
 
 typealias MakeCompilerHappyForStarterCode = FakeCallForRetrofit<String>

--- a/start/src/debug/java/com/example/android/kotlincoroutines/fakes/TestingFakes.kt
+++ b/start/src/debug/java/com/example/android/kotlincoroutines/fakes/TestingFakes.kt
@@ -148,5 +148,4 @@ class FakeCallForRetrofit<T> : Call<T> {
     override fun timeout(): Timeout {
         TODO("Not yet implemented")
     }
-
 }

--- a/start/src/main/java/com/example/android/kotlincoroutines/main/MainDatabase.kt
+++ b/start/src/main/java/com/example/android/kotlincoroutines/main/MainDatabase.kt
@@ -40,7 +40,7 @@ data class Title constructor(val title: String, @PrimaryKey val id: Int = 0)
 @Dao
 interface TitleDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertTitle(title: Title)
+    suspend fun insertTitle(title: Title)
 
     @get:Query("select * from Title where id = 0")
     val titleLiveData: LiveData<Title?>

--- a/start/src/main/java/com/example/android/kotlincoroutines/main/MainNetwork.kt
+++ b/start/src/main/java/com/example/android/kotlincoroutines/main/MainNetwork.kt
@@ -44,7 +44,7 @@ fun getNetworkService() = service
  */
 interface MainNetwork {
     @GET("next_title.json")
-    fun fetchNextTitle(): Call<String>
+    suspend fun fetchNextTitle(): String
 }
 
 

--- a/start/src/main/java/com/example/android/kotlincoroutines/main/MainViewModel.kt
+++ b/start/src/main/java/com/example/android/kotlincoroutines/main/MainViewModel.kt
@@ -19,8 +19,11 @@ package com.example.android.kotlincoroutines.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.example.android.kotlincoroutines.util.BACKGROUND
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
 import com.example.android.kotlincoroutines.util.singleArgViewModelFactory
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 /**
  * MainViewModel designed to store and manage UI-related data in a lifecycle conscious way. This
@@ -101,10 +104,9 @@ class MainViewModel(private val repository: TitleRepository) : ViewModel() {
      * Wait one second then update the tap count.
      */
     private fun updateTaps() {
-        // TODO: Convert updateTaps to use coroutines
-        tapCount++
-        BACKGROUND.submit {
-            Thread.sleep(1_000)
+        viewModelScope.launch {
+            tapCount++
+            delay(1_000)
             _taps.postValue("${tapCount} taps")
         }
     }
@@ -120,17 +122,21 @@ class MainViewModel(private val repository: TitleRepository) : ViewModel() {
      * Refresh the title, showing a loading spinner while it refreshes and errors via snackbar.
      */
     fun refreshTitle() {
-        // TODO: Convert refreshTitle to use coroutines
-        _spinner.value = true
-        repository.refreshTitleWithCallbacks(object : TitleRefreshCallback {
-            override fun onCompleted() {
-                _spinner.postValue(false)
-            }
+        launchDataLoad {
+            repository.refreshTitle()
+        }
+    }
 
-            override fun onError(cause: Throwable) {
-                _snackBar.postValue(cause.message)
-                _spinner.postValue(false)
+    private fun launchDataLoad(block: suspend () -> Unit): Job {
+        return viewModelScope.launch {
+            try {
+                _spinner.value = true
+                block()
+            } catch (error: TitleRefreshError) {
+                _snackBar.value = error.message
+            } finally {
+                _spinner.value = false
             }
-        })
+        }
     }
 }

--- a/start/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
+++ b/start/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
@@ -41,7 +41,15 @@ class RefreshMainDataWork(context: Context, params: WorkerParameters, private va
      * start just enough to run this [Worker].
      */
     override suspend fun doWork(): Result {
-        return Result.success()         // TODO: Use coroutines from WorkManager
+        val database = getDatabase(applicationContext)
+        val repository = TitleRepository(network, database.titleDao)
+
+        return try {
+            repository.refreshTitle()
+            Result.success()
+        } catch (error: TitleRefreshError) {
+            Result.failure()
+        }
     }
 
     class Factory(val network: MainNetwork = getNetworkService()) : WorkerFactory() {

--- a/start/src/main/java/com/example/android/kotlincoroutines/main/TitleRepository.kt
+++ b/start/src/main/java/com/example/android/kotlincoroutines/main/TitleRepository.kt
@@ -18,7 +18,7 @@ package com.example.android.kotlincoroutines.main
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
-import com.example.android.kotlincoroutines.util.BACKGROUND
+import kotlinx.coroutines.withTimeout
 
 /**
  * TitleRepository provides an interface to fetch a title or request a new one be generated.
@@ -41,36 +41,14 @@ class TitleRepository(val network: MainNetwork, val titleDao: TitleDao) {
      */
     val title: LiveData<String?> = titleDao.titleLiveData.map { it?.title }
 
-
-    // TODO: Add coroutines-based `fun refreshTitle` here
-
-    /**
-     * Refresh the current title and save the results to the offline cache.
-     *
-     * This method does not return the new title. Use [TitleRepository.title] to observe
-     * the current tile.
-     */
-    fun refreshTitleWithCallbacks(titleRefreshCallback: TitleRefreshCallback) {
-        // This request will be run on a background thread by retrofit
-        BACKGROUND.submit {
-            try {
-                // Make network request using a blocking call
-                val result = network.fetchNextTitle().execute()
-                if (result.isSuccessful) {
-                    // Save it to database
-                    titleDao.insertTitle(Title(result.body()!!))
-                    // Inform the caller the refresh is completed
-                    titleRefreshCallback.onCompleted()
-                } else {
-                    // If it's not successful, inform the callback of the error
-                    titleRefreshCallback.onError(
-                            TitleRefreshError("Unable to refresh title", null))
-                }
-            } catch (cause: Throwable) {
-                // If anything throws an exception, inform the caller
-                titleRefreshCallback.onError(
-                        TitleRefreshError("Unable to refresh title", cause))
+    suspend fun refreshTitle() {
+        try {
+            val result = withTimeout(5_000) {
+                network.fetchNextTitle()
             }
+            titleDao.insertTitle(Title(result))
+        } catch (cause: Throwable) {
+            throw TitleRefreshError("Unable to refresh title", cause)
         }
     }
 }

--- a/start/src/test/java/com/example/android/kotlincoroutines/main/MainViewModelTest.kt
+++ b/start/src/test/java/com/example/android/kotlincoroutines/main/MainViewModelTest.kt
@@ -20,6 +20,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.example.android.kotlincoroutines.fakes.MainNetworkFake
 import com.example.android.kotlincoroutines.fakes.TitleDaoFake
 import com.example.android.kotlincoroutines.main.utils.MainCoroutineScopeRule
+import com.example.android.kotlincoroutines.main.utils.getValueForTest
+import com.google.common.truth.Truth
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -27,6 +29,7 @@ import org.junit.Test
 class MainViewModelTest {
     @get:Rule
     val coroutineScope = MainCoroutineScopeRule()
+
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
@@ -35,14 +38,18 @@ class MainViewModelTest {
     @Before
     fun setup() {
         subject = MainViewModel(
-                TitleRepository(
-                        MainNetworkFake("OK"),
-                        TitleDaoFake("initial")
-                ))
+            TitleRepository(
+                MainNetworkFake("OK"),
+                TitleDaoFake("initial")
+            )
+        )
     }
 
     @Test
     fun whenMainClicked_updatesTaps() {
-        // TODO: Write this
+        subject.onMainViewClicked()
+        Truth.assertThat(subject.taps.getValueForTest()).isEqualTo("0 taps")
+        coroutineScope.advanceTimeBy(1000)
+        Truth.assertThat(subject.taps.getValueForTest()).isEqualTo("1 taps")
     }
 }

--- a/start/src/test/java/com/example/android/kotlincoroutines/main/TitleRepositoryTest.kt
+++ b/start/src/test/java/com/example/android/kotlincoroutines/main/TitleRepositoryTest.kt
@@ -17,6 +17,12 @@
 package com.example.android.kotlincoroutines.main
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.android.kotlincoroutines.fakes.MainNetworkCompletableFake
+import com.example.android.kotlincoroutines.fakes.MainNetworkFake
+import com.example.android.kotlincoroutines.fakes.TitleDaoFake
+import com.google.common.truth.Truth
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,13 +32,26 @@ class TitleRepositoryTest {
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @Test
-    fun whenRefreshTitleSuccess_insertsRows() {
-        // TODO: Write this test
+    fun whenRefreshTitleSuccess_insertsRows() = runBlockingTest {
+        val titleDao = TitleDaoFake("title")
+        val subject = TitleRepository(
+            MainNetworkFake("OK"),
+            titleDao
+        )
+        subject.refreshTitle()
+        Truth.assertThat(titleDao.nextInsertedOrNull()).isEqualTo("OK")
     }
 
     @Test(expected = TitleRefreshError::class)
-    fun whenRefreshTitleTimeout_throws() {
-        // TODO: Write this test
-        throw TitleRefreshError("Remove this – made test pass in starter code", null)
+    fun whenRefreshTitleTimeout_throws() = runBlockingTest {
+        val network = MainNetworkCompletableFake()
+        val subject = TitleRepository(
+            network,
+            TitleDaoFake("title")
+        )
+        launch {
+            subject.refreshTitle()
+        }
+        advanceTimeBy(5_000)
     }
 }


### PR DESCRIPTION
Concludes the https://developer.android.com/codelabs/kotlin-coroutines codelab and closes the issue https://github.com/profusion/quickstart-android-jetpack-graphql/issues/209

The objective of this tutorial was to undestand the use of coroutines in kotlin converting a existing project that managed the threads explicitly to use coroutines.

[untitled.webm](https://user-images.githubusercontent.com/18041717/193277262-dc2aa1f4-51e9-4add-b2f9-5d0bd1c34263.webm)
